### PR TITLE
Don't overwrite `twigOptions` when merging

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var twigOptions = {
 
 exports.renderFile = function(entry, options, cb) {
   // Merge the global options with the local ones.
-  options = Object.assign(twigOptions, options);
+  options = Object.assign({}, twigOptions, options);
 
   execPHP('php/Twig.php', null, function (error, php) {
     // Call the callback on error or the render function on success.


### PR DESCRIPTION
`Object.assign(target, source)` writes the values of `source` onto `target` and then returns it (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign), meaning that `twigOptions` was being modified by every call to `renderFile`.

When using `twig-node` to render a batch of templates (e.g. iterating an array of `context`s from JSON files), this results in the `options` object getting corrupted by subsequent async calls to `renderFile` before each PHP execution has resolved.

This small modification provides an empty object as the `assign` target that prevents pollution.