### PR TITLE
Updating exec-php to remove deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "colors": "^1.1.2",
-    "exec-php": "0.0.3",
+    "exec-php": "^0.0.4",
     "trim": "0.0.1"
   },
   "scripts": {


### PR DESCRIPTION
Currently there will be lots of this output in the command line:

```
(node:79446) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
```

This is caused by `exec-php` at v0.0.3 and was fixed in v0.0.4; this PR simply updates to that new version.